### PR TITLE
Remove Hidden Class Variants Container

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -130,7 +130,7 @@
     </div>
 
     {% if productType.hasVariants %}
-        <div id="variants-container"{% if tabs|length %} class="hidden"{% endif %}>
+        <div id="variants-container">
             <div class="field">
                 <div class="heading">
                     <label>{{ 'Variants'|t('commerce') }}</label>


### PR DESCRIPTION
Fixed the problem that the `id="variants-container"` is hidden when there tabs exists on the product type.